### PR TITLE
Add agent user to sudoers

### DIFF
--- a/configure_metrics_agent.sh
+++ b/configure_metrics_agent.sh
@@ -3,6 +3,11 @@
 echo "Configuring agent..."
 BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 INSTALL_DIR=`cd $BIN_DIR/.. && pwd`
+MON_SUDUERS_FILE="/etc/sudoers.d/mon-agent"
+
+if [ ! -e ${MON_SUDUERS_FILE} ]; then
+    echo "mon-agent ALL=(ALL) NOPASSWD:ALL" | sudo tee ${MON_SUDUERS_FILE} >> /dev/null
+fi
 
 sudo mkdir -p /etc/monasca
 


### PR DESCRIPTION
Auto-detection for postfix was failed because agent user couldn't access
postfix directory so this change adds root authorization to agent user.
Add agent user to sudoers to execute monasca-setup command properly.