### PR TITLE
Hint when user enters directory instead of file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ Use the following arguments to modify the default values of the`agent.conf` file
     --hostname <hostname for dimensions> \
     <input_file_path_1> <input_file_path_2> <input_file_path_n>
 ```
+To include all the files in a directory, use the `*` wild card (eg. `/var/log/*` ).
+
 Additionally, you can add the `--no_service` to omit the step of automatically creating `monasca-log-agent.service` in `/etc/systemd/system/`
 
 ### Monasca-ui

--- a/configure_log_agent.sh
+++ b/configure_log_agent.sh
@@ -88,14 +88,6 @@ generate_config_file() {
       }
     }" >> ${INSTALL_DIR}/conf/agent.conf
 
-    if [ ! -z "$BAD_PATHS" ]; then
-        for path in $BAD_PATHS
-        do
-            echo "Warning!"
-            echo "Not a file path: $path - To select all files from directory, use an asterisk: $path*"
-        done
-    fi
-
     echo "agent.conf successfully created in $INSTALL_DIR/conf/"
 }
 

--- a/configure_log_agent.sh
+++ b/configure_log_agent.sh
@@ -54,19 +54,19 @@ generate_config_file() {
 
     if [ -z "$FILES" ]
     then
-        echo -e "No file paths were specified for input -- The agents.conf file
+        echo -e "WARNING: No file paths were specified for input -- The agents.conf file
     was successfully created, but you may wish to re-run this command
     with any number of paths for input files at the end of your list
     of arguments"
     else
         for file in $FILES
         do
-
-        echo -e "   file {
-        #   add_field => { \"dimensions\" => { \"service\" => \"system\" }}
-            path => \"$file\"
-          }">> ${INSTALL_DIR}/conf/agent.conf
-
+            if [ ! -d $file ]; then
+                echo -e "   file {
+                #   add_field => { \"dimensions\" => { \"service\" => \"system\" }}
+                    path => \"$file\"
+                  }">> ${INSTALL_DIR}/conf/agent.conf
+            fi
         done
     fi
 
@@ -85,6 +85,14 @@ generate_config_file() {
       }
     }" >> ${INSTALL_DIR}/conf/agent.conf
 
+    if [ ! -z "$BAD_PATHS" ]; then
+        for path in $BAD_PATHS
+        do
+            echo "Warning!"
+            echo "Not a file path: $path - To select all files from directory, use an asterisk: $path*"
+        done
+    fi
+
     echo "agent.conf successfully created in $INSTALL_DIR/conf/"
 }
 
@@ -98,6 +106,7 @@ PASSWORD="password"
 USER_DOMAIN_NAME="default"
 PROJECT_DOMAIN_NAME="default"
 NO_SERVICE=false
+BAD_PATHS=""
 FILES=""
 
 # check for additional arguments in call to override default values (above)
@@ -141,6 +150,10 @@ do
         -h|--hostname)
         HOSTNAME="$2"
         shift 2
+        ;;
+        */)
+        BAD_PATHS+="$1 "
+        shift
         ;;
         *)    # unknown option
         FILES+="$1 " # save it in an array for later

--- a/configure_log_agent.sh
+++ b/configure_log_agent.sh
@@ -66,6 +66,8 @@ generate_config_file() {
                 #   add_field => { \"dimensions\" => { \"service\" => \"system\" }}
                     path => \"$file\"
                   }">> ${INSTALL_DIR}/conf/agent.conf
+            else
+                echo "$file is a directory. Only files can be monitored - skipping."
             fi
         done
     fi
@@ -106,7 +108,6 @@ PASSWORD="password"
 USER_DOMAIN_NAME="default"
 PROJECT_DOMAIN_NAME="default"
 NO_SERVICE=false
-BAD_PATHS=""
 FILES=""
 
 # check for additional arguments in call to override default values (above)
@@ -150,10 +151,6 @@ do
         -h|--hostname)
         HOSTNAME="$2"
         shift 2
-        ;;
-        */)
-        BAD_PATHS+="$1 "
-        shift
         ;;
         *)    # unknown option
         FILES+="$1 " # save it in an array for later


### PR DESCRIPTION
When user enters a directory instead of a file path, prompt to select all files with syntax: `/directory/*`. Also, when user enters `/directory/*`, sub-directory paths that are not file paths are not written to the config file. 