### PR TITLE
Add default log agent configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ To include all the files in a directory, use the `*` wild card (eg. `/var/log/*`
 | `user_domain_name`    | no       | `default`                      |                                | User domain id for username scoping |
 | `project_domain_name` | no       | `default`                      |                                | Project domain id for keystone authentication |
 | `hostname`            | no       | `hostname`                     | `myhostname`                   | Hostname |
-| `input_file_path_n`   | yes      | `unset`                        | `/var/log/*`                   | Input log file path |
+| `input_file_path_n`   | no       | `unset`                        | `/var/log/*`                   | Input log file path. **If this variable is not specified, default log agent configuration file is created.** |
 
 Additionally, you can add the `--no_service` to omit the step of automatically creating `monasca-log-agent.service` in `/etc/systemd/system/`
 

--- a/agent.conf.j2
+++ b/agent.conf.j2
@@ -1,0 +1,34 @@
+input {
+{%- for input_value in input %}
+  file {
+    add_field => {{ input_value.dimensions }}
+    tags => {{ input_value.tags }}
+    path => {{ input_value.path }}
+  }
+{%- endfor %}
+}
+
+filter {
+{%- for filter_value in filter %}
+  if {{ filter_value.type }} in [tags] {
+    {{ filter_value.name }} {
+      negate => {{ filter_value.negate }}
+      pattern => {{ filter_value.pattern }}
+      what => {{ filter_value.what }}
+    }
+  }
+{%- endfor %}
+}
+
+output {
+  monasca_log_api {
+    monasca_log_api_url => "{{ output.monasca_log_api_url }}"
+    keystone_api_url => "{{ output.keystone_api_url }}"
+    project_name => "{{ output.project_name }}"
+    username => "{{ output.username }}"
+    password => "{{ output.password }}"
+    user_domain_name => "{{ output.user_domain_name }}"
+    project_domain_name => "{{ output.project_domain_name }}"
+    dimensions => ["hostname:{{ output.dimensions }}"]
+  }
+}

--- a/create_log_agent_installer.sh
+++ b/create_log_agent_installer.sh
@@ -20,6 +20,10 @@ mkdir -p ${LOG_AGENT_TMP_DIR}/conf
 ${LOG_AGENT_TMP_DIR}/logstash-${LOGSTASH_VERSION}/bin/logstash-plugin \
     install ${TMP_DIR}/logstash-output-monasca_log_api-${LOGSTASH_OUTPUT_MONASCA_LOG_API_VERSION}.gem
 cp configure_log_agent.sh ${LOG_AGENT_TMP_DIR}/bin
+cp set_config.py ${LOG_AGENT_TMP_DIR}/bin
+cp agent.conf.j2 ${LOG_AGENT_TMP_DIR}/conf
+cp input.ini ${LOG_AGENT_TMP_DIR}/conf
+cp filter.ini ${LOG_AGENT_TMP_DIR}/conf
 
 if [ -d "${MAKESELF_DIR}" ]; then
     cd ${MAKESELF_DIR}

--- a/filter.ini
+++ b/filter.ini
@@ -1,0 +1,30 @@
+# Copyright 2017 FUJITSU LIMITED
+#
+# Licensed under the Apache License, Version 2.0 (the \"License\");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an \"AS IS\" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Default configuration for filter section of agent.conf
+[openstack]
+name = multiline
+type = "openstack"
+negate = "true"
+pattern = "^%{TIMESTAMP_ISO8601}%{SPACE}%{NUMBER}%{SPACE}(CRITICAL|ERROR|WARNING|INFO|DEBUG|EXCEPTION|NOTSET)"
+what = "previous"
+
+[syslog]
+name = multiline
+type = "syslog"
+negate = "true"
+pattern = "^%{SYSLOGTIMESTAMP}"
+what = "previous"

--- a/input.ini
+++ b/input.ini
@@ -1,0 +1,196 @@
+# Copyright 2017 FUJITSU LIMITED
+#
+# Licensed under the Apache License, Version 2.0 (the \"License\");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an \"AS IS\" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Default configuration for input section of agent.conf
+[messages]
+add_field = { "dimensions" => { "service" => "system" }}
+tags = ["syslog"]
+path = "/var/log/messages"
+
+[keystone-admin]
+add_field = { "dimensions" => { "service" => "keystone" "component" => "keystone-admin" }}
+tags = ["openstack"]
+path = "/var/log/keystone/admin.log"
+
+[keystone-main]
+add_field = { "dimensions" => { "service" => "keystone" "component" => "keystone-main" }}
+tags = ["openstack"]
+path = "/var/log/keystone/main.log"
+
+[keystone]
+add_field = { "dimensions" => { "service" => "keystone" }}
+tags = ["openstack"]
+path = "/var/log/keystone/keystone.log"
+
+[glance-api]
+add_field = { "dimensions" => { "service" => "glance" "component" => "glance-api" }}
+tags = ["openstack"]
+path = "/var/log/glance/api.log"
+
+[glance-registry]
+add_field = { "dimensions" => { "service" => "glance" "component" => "glance-registry" }}
+tags = ["openstack"]
+path = "/var/log/glance/registry.log"
+
+[cinder-api]
+add_field = { "dimensions" => { "service" => "cinder" "component" => "cinder-api" }}
+tags = ["openstack"]
+path = "/var/log/cinder/api.log"
+
+[cinder-backup]
+add_field = { "dimensions" => { "service" => "cinder" "component" => "cinder-backup" }}
+tags = ["openstack"]
+path = "/var/log/cinder/backup.log"
+
+[cinder-manager]
+add_field = { "dimensions" => { "service" => "cinder" "component" => "cinder-manager" }}
+tags = ["openstack"]
+path = "/var/log/cinder/cinder-manager.log"
+
+[cinder-scheduler]
+add_field = { "dimensions" => { "service" => "cinder" "component" => "cinder-scheduler" }}
+tags = ["openstack"]
+path = "/var/log/cinder/scheduler.log"
+
+[cinder-volume]
+add_field = { "dimensions" => { "service" => "cinder" "component" => "cinder-volume" }}
+tags = ["openstack"]
+path = "/var/log/cinder/volume.log"
+
+[ceilometer-agent]
+add_field = { "dimensions" => { "service" => "ceilometer" "component" => "ceilometer-agent" }}
+tags = ["openstack"]
+path = "/var/log/ceilometer/agent-notification.log"
+
+[ceilometer-alarm-evaluator]
+add_field = { "dimensions" => { "service" => "ceilometer" "component" => "ceilometer-alarm-evaluator" }}
+tags = ["openstack"]
+path = "/var/log/ceilometer/alarm-evaluator.log"
+
+[ceilometer-alarm-notifier]
+add_field = { "dimensions" => { "service" => "ceilometer" "component" => "ceilometer-alarm-notifier" }}
+tags = ["openstack"]
+path = "/var/log/ceilometer/alarm-notifier.log"
+
+[ceilometer-api]
+add_field = { "dimensions" => { "service" => "ceilometer" "component" => "ceilometer-api" }}
+tags = ["openstack"]
+path = "/var/log/ceilometer/api.log"
+
+[ceilometer-dbsync]
+add_field = { "dimensions" => { "service" => "ceilometer" "component" => "ceilometer-dbsync" }}
+tags = ["openstack"]
+path = "/var/log/ceilometer/ceilometer-dbsync.log"
+
+[ceilometer-central]
+add_field = { "dimensions" => { "service" => "ceilometer" "component" => "ceilometer-central" }}
+tags = ["openstack"]
+path = "/var/log/ceilometer/central.log"
+
+[ceilometer-collector]
+add_field = { "dimensions" => { "service" => "ceilometer" "component" => "ceilometer-collector" }}
+tags = ["openstack"]
+path = "/var/log/ceilometer/collector.log"
+
+[ceilometer-compute]
+add_field = { "dimensions" => { "service" => "ceilometer" "component" => "ceilometer-compute" }}
+tags = ["openstack"]
+path = "/var/log/ceilometer/compute.log"
+
+[nova-api]
+add_field = { "dimensions" => { "service" => "nova" "component" => "nova-api" }}
+tags = ["openstack"]
+path = "/var/log/nova/nova-api.log"
+
+[nova-cert]
+add_field = { "dimensions" => { "service" => "nova" "component" => "nova-cert" }}
+tags = ["openstack"]
+path = "/var/log/nova/nova-cert.log"
+
+[nova-compute]
+add_field = { "dimensions" => { "service" => "nova" "component" => "nova-compute" }}
+tags = ["openstack"]
+path = "/var/log/nova/nova-compute.log"
+
+[nova-conductor]
+add_field = { "dimensions" => { "service" => "nova" "component" => "nova-conductor" }}
+tags = ["openstack"]
+path = "/var/log/nova/nova-conductor.log"
+
+[nova-consoleauth]
+add_field = { "dimensions" => { "service" => "nova" "component" => "nova-consoleauth" }}
+tags = ["openstack"]
+path = "/var/log/nova/nova-consoleauth.log"
+
+[nova-manage]
+add_field = { "dimensions" => { "service" => "nova" "component" => "nova-manage" }}
+tags = ["openstack"]
+path = "/var/log/nova/nova-manage.log"
+
+[nova-novncproxy]
+add_field = { "dimensions" => { "service" => "nova" "component" => "nova-novncproxy" }}
+tags = ["openstack"]
+path = "/var/log/nova/nova-novncproxy.log"
+
+[nova-scheduler]
+add_field = { "dimensions" => { "service" => "nova" "component" => "nova-scheduler" }}
+tags = ["openstack"]
+path = "/var/log/nova/nova-scheduler.log"
+
+[neutron-server]
+add_field = { "dimensions" => { "service" => "neutron" "component" => "neutron-server" }}
+tags = ["openstack"]
+path = "/var/log/neutron/server.log"
+
+[neutron-l3-agent]
+add_field = { "dimensions" => { "service" => "neutron" "component" => "neutron-l3-agent" }}
+tags = ["openstack"]
+path = "/var/log/neutron/l3-agent.log"
+
+[neutron-metadata-agent]
+add_field = { "dimensions" => { "service" => "neutron" "component" => "neutron-metadata-agent" }}
+tags = ["openstack"]
+path = "/var/log/neutron/metadata-agent.log"
+
+[neutron-openvswitch-agent]
+add_field = { "dimensions" => { "service" => "neutron" "component" => "neutron-openvswitch-agent" }}
+tags = ["openstack"]
+path = "/var/log/neutron/openvswitch-agent.log"
+
+[neutron-dhcp-agent]
+add_field = { "dimensions" => { "service" => "neutron" "component" => "neutron-dhcp-agent" }}
+tags = ["openstack"]
+path = "/var/log/neutron/dhcp-agent.log"
+
+[neutron-ovs-cleanup]
+add_field = { "dimensions" => { "service" => "neutron" "component" => "neutron-ovs-cleanup" }}
+tags = ["openstack"]
+path = "/var/log/neutron/ovs-cleanup.log"
+
+[ovsdb-server]
+add_field = { "dimensions" => { "service" => "openvswitch" "component" => "ovsdb-server" }}
+tags = ["openstack"]
+path = "/var/log/openvswitch/ovsdb-server.log"
+
+[ovs-vswitchd]
+add_field = { "dimensions" => { "service" => "openvswitch" "component" => "ovs-vswitchd" }}
+tags = ["openstack"]
+path = "/var/log/openvswitch/ovs-vswitchd.log"
+
+[swift]
+add_field = { "dimensions" => { "service" => "swift" }}
+tags = ["syslog"]
+path = "/var/log/swift/*"

--- a/set_config.py
+++ b/set_config.py
@@ -1,0 +1,96 @@
+# Copyright 2017 FUJITSU LIMITED
+#
+# Licensed under the Apache License, Version 2.0 (the \"License\");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an \"AS IS\" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import ConfigParser
+import sys
+from jinja2 import Template
+from optparse import OptionParser
+
+
+def main():
+    parser = OptionParser()
+    parser.add_option("--tmp_config", dest = "tmp_config")
+    parser.add_option("--config", dest = "config")
+    parser.add_option("--input_ini", dest = "input_ini")
+    parser.add_option("--filter_ini", dest = "filter_ini")
+    parser.add_option("--monasca_log_api_url", dest = "monasca_log_api_url")
+    parser.add_option("--keystone_auth_url", dest = "keystone_auth_url")
+    parser.add_option("--project_name", dest = "project_name")
+    parser.add_option("--username", dest = "username")
+    parser.add_option("--password", dest = "password")
+    parser.add_option("--user_domain_name", dest = "user_domain_name")
+    parser.add_option("--project_domain_name", dest = "project_domain_name")
+    parser.add_option("--hostname", dest = "hostname")
+
+    options, args = parser.parse_args()
+
+    in_path = options.tmp_config
+    out_path = options.config
+    input_ini_path = options.input_ini
+    filter_ini_path = options.filter_ini
+    monasca_log_api_url = options.monasca_log_api_url
+    keystone_auth_url = options.keystone_auth_url
+    project_name = options.project_name
+    username = options.username
+    password = options.password
+    user_domain_name = options.user_domain_name
+    project_domain_name = options.project_domain_name
+    hostname = options.hostname
+
+    config_input = ConfigParser.ConfigParser()
+    config_input.read(input_ini_path)
+
+    input_config = []
+
+    for section in config_input.sections():
+        input_demensions = config_input.get(section, "add_field")
+        input_path = config_input.get(section, "path")
+        input_tags = config_input.get(section, "tags")
+        input_config.append({"dimensions": input_demensions, "path": input_path,
+                             "tags": input_tags})
+
+    config_filter = ConfigParser.ConfigParser()
+    config_filter.read(filter_ini_path)
+
+    filter_config = []
+
+    for section in config_filter.sections():
+        filter_name = config_filter.get(section, "name")
+        filter_type = config_filter.get(section, "type")
+        filter_negate = config_filter.get(section, "negate")
+        filter_pattern = config_filter.get(section, "pattern")
+        filter_what = config_filter.get(section, "what")
+        filter_negate = config_filter.get(section, "negate")
+        filter_config.append({"name": filter_name, "type": filter_type,
+                              "pattern": filter_negate, "what": filter_what,
+                              "negate": filter_negate})
+
+    output_config = {"monasca_log_api_url": monasca_log_api_url,
+                     "keystone_api_url": keystone_auth_url,
+                     "project_name": project_name,
+                     "username": username,
+                     "password": password,
+                     "user_domain_name": user_domain_name,
+                     "project_domain_name": project_domain_name,
+                     "dimensions": hostname}
+
+    with open(in_path, 'r') as in_file, open(out_path, 'w') as out_file:
+        t = Template(in_file.read())
+        out_file.write(t.render({"input": input_config, "filter": filter_config,
+                                 "output": output_config}))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Only path of input section in log agent configuration could be set by
running installer with arguments "input_file_path_n". This change makes
it possible that the other following configuration could be set by
preparing default configuration file.

input section:
- add_field
- tags

filter section:
- filter name
- negate
- pattern
- what