### PR TITLE
Include Libvirt dependency packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ To use the latest version of monasca-agent, simply run
 
 To use a specific version of monasca-agent, add the desired version number and upper constraints file as an argument:
 ```
-./create_metrics_agent_installer.sh <version_number> <upper_constraints_file>
+./create_metrics_agent_installer.sh -v <version_number> -u <upper_constraints_file>
 ```
 
 You can find an example of an upper constraints file [here](http://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/pike).
 
+Additionally, you can add the `--install_libvirt_dependencies` to install python packages for libvirt.
 Either way, this will generate a new executable named: `monasca-agent-<version_number>.run` .
 
 ### Log agent

--- a/create_metrics_agent_installer.sh
+++ b/create_metrics_agent_installer.sh
@@ -3,27 +3,63 @@ source commons
 
 # takes the first argument as the version. Defaults to the latest version
 # of monasca-agent if no argument is specified.
-MONASCA_AGENT_VERSION=${1:-`pip search monasca-agent | grep monasca-agent | \
-                            awk '{print $2}' | sed 's|(||' | sed 's|)||'`}
-UPPER_CONSTRAINT_FILE=${2:-""}
+MONASCA_AGENT_VERSION=`pip search monasca-agent | grep monasca-agent | \
+                        awk '{print $2}' | sed 's|(||' | sed 's|)||'`
+UPPER_CONSTRAINTS_FILE=""
+INSTALL_LIBVIRT_DEPENDENCIES=false
+
+# check for additional arguments in call to override default values (above)
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+
+    case $key in
+        -v|--monasca_agent_version)
+        MONASCA_AGENT_VERSION="$2"
+        shift 2
+        ;;
+        -u|--upper_constraints_file)
+        UPPER_CONSTRAINTS_FILE="$2"
+        shift 2
+        ;;
+        --install_libvirt_dependencies)
+        INSTALL_LIBVIRT_DEPENDENCIES=true
+        shift
+        ;;
+        *)    # unknown option
+        shift
+        ;;
+    esac
+done
 
 MONASCA_AGENT_TMP_DIR="${TMP_DIR}/monasca-agent"
 PIP_DEPENDENCIES=("pymysql")
+LIBVIRT_DEPENDENCIES=("libvirt-python" "lxml" "python-neutronclient" "python-novaclient")
 
 mkdir -p ${MONASCA_AGENT_TMP_DIR}
 
 virtualenv ${MONASCA_AGENT_TMP_DIR}
 
-if [ -z "${UPPER_CONSTRAINT_FILE}" ]; then
-    for dependencies in ${PIP_DEPENDENCIES[@]}; do
-        ${MONASCA_AGENT_TMP_DIR}/bin/pip install $dependencies
-    done
+if [ -z "${UPPER_CONSTRAINTS_FILE}" ]; then
     ${MONASCA_AGENT_TMP_DIR}/bin/pip install monasca-agent==$MONASCA_AGENT_VERSION
-else
-    for dependencies in ${PIP_DEPENDENCIES[@]}; do
-        ${MONASCA_AGENT_TMP_DIR}/bin/pip install -c ${UPPER_CONSTRAINT_FILE} $dependencies
+    for pip_dependencies in ${PIP_DEPENDENCIES[@]}; do
+        ${MONASCA_AGENT_TMP_DIR}/bin/pip install $pip_dependencies
     done
-    ${MONASCA_AGENT_TMP_DIR}/bin/pip install -c ${UPPER_CONSTRAINT_FILE} monasca-agent==$MONASCA_AGENT_VERSION
+    if [ ${INSTALL_LIBVIRT_DEPENDENCIES} = true ]; then
+        for libvirt_dependencies in ${LIBVIRT_DEPENDENCIES[@]}; do
+            ${MONASCA_AGENT_TMP_DIR}/bin/pip install $libvirt_dependencies
+        done
+    fi
+else
+    ${MONASCA_AGENT_TMP_DIR}/bin/pip install -c ${UPPER_CONSTRAINTS_FILE} monasca-agent==$MONASCA_AGENT_VERSION
+    for dependencies in ${PIP_DEPENDENCIES[@]}; do
+        ${MONASCA_AGENT_TMP_DIR}/bin/pip install -c ${UPPER_CONSTRAINTS_FILE} $dependencies
+    done
+    if [ ${INSTALL_LIBVIRT_DEPENDENCIES} = true ]; then
+        for libvirt_dependencies in ${LIBVIRT_DEPENDENCIES[@]}; do
+            ${MONASCA_AGENT_TMP_DIR}/bin/pip install -c ${UPPER_CONSTRAINTS_FILE} $libvirt_dependencies
+        done
+    fi
 fi
 virtualenv --relocatable ${MONASCA_AGENT_TMP_DIR}
 


### PR DESCRIPTION
Make it possible to include following Libvirt dependency packages in
metric agent installer.
- libvirt-python
- lxml
- python-neutronclient
- python-novaclient