### PR TITLE
Fix setting proper permissions on agents config files

### DIFF
--- a/configure_log_agent.sh
+++ b/configure_log_agent.sh
@@ -5,12 +5,14 @@ error() { log "ERROR: $1"; }
 warn() { log "WARNING: $1"; }
 inf() { log "INFO: $1"; }
 
-inf "Configuring log agent..."
 BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 INSTALL_DIR="$(cd "$BIN_DIR/.." && pwd)"
 LOGSTASH_DIR="$INSTALL_DIR/$(ls "$BIN_DIR/.." | grep logstash)"
 
 MON_LOG_AGENT_LOG_DIR="/var/log/monasca-log-agent"
+
+inf "Installation directory: ${INSTALL_DIR}"
+inf "Configuring log agent..."
 
 # Creates monasca-log-agent.service file in etc/systemd/system/ with 0664 permissions
 create_system_service_file() {

--- a/configure_metrics_agent.sh
+++ b/configure_metrics_agent.sh
@@ -5,7 +5,6 @@ error() { log "ERROR: $1"; }
 warn() { log "WARNING: $1"; }
 inf() { log "INFO: $1"; }
 
-inf "Configuring agent..."
 BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 INSTALL_DIR=$( cd "$BIN_DIR/.." && pwd )
 MON_SUDOERS_FILE="/etc/sudoers.d/mon-agent"
@@ -13,6 +12,9 @@ MON_SUDOERS_FILE="/etc/sudoers.d/mon-agent"
 MON_AGENT_DIR="/etc/monasca/agent"
 MON_SYSTEMD_DIR="/etc/systemd/system"
 MON_DEFAULT_AGENT_LOG_DIR="/var/log/monasca-agent"
+
+inf "Installation directory: ${INSTALL_DIR}"
+inf "Configuring metrics agent..."
 
 if [ ! -e "${MON_SUDOERS_FILE}" ]; then
     echo "mon-agent ALL=(ALL) NOPASSWD:ALL" | sudo tee "${MON_SUDOERS_FILE}" >> /dev/null

--- a/configure_metrics_agent.sh
+++ b/configure_metrics_agent.sh
@@ -33,7 +33,8 @@ function protect_overwrite() {
         if [ "${OVERWRITE_CONF}" = "false" ]; then
             warn "${protected_file} already exists"
             warn "If you want to overwrite it you need to use '--overwrite_conf'"
-            \cp -f "${protected_file}" "${protected_file}.backup"
+            # Create backup with preserving permissions
+            \cp -pf "${protected_file}" "${protected_file}.backup"
             return
         else
             inf "Existing ${protected_file} file will be overwritten"

--- a/configure_metrics_agent.sh
+++ b/configure_metrics_agent.sh
@@ -36,7 +36,7 @@ function protect_overwrite() {
             warn "${protected_file} already exists"
             warn "If you want to overwrite it you need to use '--overwrite_conf'"
             # Create backup with preserving permissions
-            \cp -pf "${protected_file}" "${protected_file}.backup"
+            \cp -f --preserve "${protected_file}" "${protected_file}.backup"
             return
         else
             inf "Existing ${protected_file} file will be overwritten"

--- a/configure_metrics_agent.sh
+++ b/configure_metrics_agent.sh
@@ -170,7 +170,6 @@ ExecStart=${BIN_DIR}/supervisord -c /etc/monasca/agent/supervisor.conf -n
 WantedBy=multi-user.target" > "${tmp_service_file}"
 
     sudo cp -f "${tmp_service_file}" "${systemd_file}"
-    sudo chown mon-agent:mon-agent "${systemd_file}"
     sudo chmod 0664 "${systemd_file}"
     sudo systemctl daemon-reload
     rm -rf "${tmp_service_file}"

--- a/configure_monasca_ui.sh
+++ b/configure_monasca_ui.sh
@@ -5,9 +5,11 @@ error() { log "ERROR: $1"; }
 warn() { log "WARNING: $1"; }
 inf() { log "INFO: $1"; }
 
-inf "Configuring monasca-ui Horizon plugin..."
 BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 INSTALL_DIR="$(cd "$BIN_DIR/.." && pwd)"
+
+inf "Installation directory: ${INSTALL_DIR}"
+inf "Configuring monasca-ui Horizon plugin..."
 
 function process_config() {
   LOCAL_SETTINGS_FILE=$(find "${INSTALL_DIR}" -name local_settings.py)


### PR DESCRIPTION
Looks like my changes that added option to not overwrite config files by default create some problems with permissions for config and service files.

