### PR TITLE
Specify timeout value when stopping log-agent

### DIFF
--- a/configure_log_agent.sh
+++ b/configure_log_agent.sh
@@ -40,7 +40,7 @@ create_system_service_file() {
     [Service]
     User = root
     Group = root
-    TimeoutStopSec = infinity
+    TimeoutStopSec = 90
     KillMode = process
     Environment = \"SINCEDB_DIR=${LOGSTASH_SINCEDB_DIR}\"
     ExecStart = $LOGSTASH_DIR/bin/logstash --config $INSTALL_DIR/conf/agent.conf --log ${MON_LOG_AGENT_LOG_DIR}/log-agent.log

--- a/create_log_agent_installer.sh
+++ b/create_log_agent_installer.sh
@@ -11,7 +11,7 @@ inf() { log "INFO: $1"; }
 # takes the first argument as the version. Defaults to the latest version
 # of monasca-agent if no argument is specified.
 LOGSTASH_VERSION=${1:-2.4.1}
-LOGSTASH_OUTPUT_MONASCA_LOG_API_VERSION=${2:-1.0.2}
+LOGSTASH_OUTPUT_MONASCA_LOG_API_VERSION=${2:-1.0.3}
 
 LOG_AGENT_TMP_DIR="${TMP_DIR}/monasca-log-agent"
 


### PR DESCRIPTION
Thus, the log-agent has enough time to handle any entries in internal
queue before stopping
Fixes #44