### PR TITLE
Fix syntax in Log-agent inpunt.ini

### DIFF
--- a/input.ini
+++ b/input.ini
@@ -35,7 +35,7 @@ pattern = "^%{TIMESTAMP_ISO8601}%{SPACE}%{NUMBER}%{SPACE}(CRITICAL|ERROR|WARNING
 what = "previous"
 
 [keystone-wsgi-admin-access]
-add_field = { "dimensions" => { "service" => "keystone "component" => "keystone-wsgi-admin-access" }}
+add_field = { "dimensions" => { "service" => "keystone" "component" => "keystone-wsgi-admin-access" }}
 tags = ["openstack"]
 path = "/var/log/containers/httpd/keystone_wsgi_admin_access.log"
 name = multiline


### PR DESCRIPTION
The missing quotes break the execution:
"exception=>""LogStash::ConfigurationError"

```
systemctl status monasca-log-agent.service 
   monasca-log-agent.service
   Loaded: loaded (/etc/systemd/system/monasca-log-agent.service; enabled; vendor preset: disabled)
   Active: activating (auto-restart) (Result: exit-code) since Sun 2021-05-02 18:02:43 UTC; 9s ago
  Process: 786340 ExecStart=/opt/monasca-log-agent/logstash-7.3.0/bin/logstash --path.config /opt/monasca-log-agent/conf/agent.conf --path.logs /var/log/monasca-log-agent (code=exited, status=1/FAILURE)
 Main PID: 786340 (code=exited, status=1/FAILURE)
```